### PR TITLE
Bump backend for Find Dependents speedup

### DIFF
--- a/node_modules/app-root/node_modules/filing-cabinet/.npmignore
+++ b/node_modules/app-root/node_modules/filing-cabinet/.npmignore
@@ -1,0 +1,8 @@
+test
+.gitignore
+.jscsrc
+.jshintrc
+.travis.yml
+.deprc
+readme.md
+webpack.config.js

--- a/node_modules/app-root/node_modules/filing-cabinet/bin/cli.js
+++ b/node_modules/app-root/node_modules/filing-cabinet/bin/cli.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var program = require('commander');
+var cabinet = require('../');
+
+program
+  .version(require('../package.json').version)
+  .usage('[options] <path>')
+  .option('-d, --directory <path>', 'root of all files')
+  .option('-c, --config [path]', 'location of a RequireJS config file for AMD')
+  .option('-w, --webpack-config [path]', 'location of a webpack config file')
+  .option('-f, --filename [path]', 'file containing the dependency')
+  .parse(process.argv);
+
+var filename = program.filename;
+var directory = program.directory;
+var config = program.config;
+var webpackConfig = program.webpackConfig;
+var dep = program.args[0];
+
+var result = cabinet({
+  partial: dep,
+  filename: filename,
+  directory: directory,
+  config: config,
+  webpackConfig: webpackConfig
+});
+
+console.log(result);

--- a/node_modules/app-root/node_modules/filing-cabinet/index.js
+++ b/node_modules/app-root/node_modules/filing-cabinet/index.js
@@ -11,25 +11,28 @@ var sassLookup = require('sass-lookup');
 var resolveDependencyPath = require('resolve-dependency-path');
 
 var appModulePath = require('app-module-path');
+var assign = require('object-assign');
 var fileExists = require('file-exists');
 
 var webpackResolve = require('enhanced-resolve');
 
-var defaultLookups = {
-  '.js': jsLookup,
-  '.scss': sassLookup,
-  '.sass': sassLookup,
-  '.styl': stylusLookup
-};
+var defaultLookups = {};
 
-module.exports = function cabinet(options) {
+module.exports = function(options) {
+  // Lazy binding for test stubbing purposes
+  assign(defaultLookups, {
+    '.js': jsLookup,
+    '.scss': sassLookup,
+    '.sass': sassLookup,
+    '.styl': stylusLookup
+  });
+
   var partial = options.partial;
   var filename = options.filename;
   var directory = options.directory;
   var config = options.config;
   var webpackConfig = options.webpackConfig;
   var configPath = options.configPath;
-  var ast = options.ast;
 
   var ext = path.extname(filename);
 
@@ -43,7 +46,7 @@ module.exports = function cabinet(options) {
   debug('found a resolver for ' + ext);
 
   // TODO: Change all resolvers to accept an options argument
-  var result = resolver(partial, filename, directory, config, webpackConfig, configPath, ast);
+  var result = resolver(partial, filename, directory, config, webpackConfig, configPath);
 
   // TODO: Remove. All resolvers should provide a complete path
   if (result && !path.extname(result)) {
@@ -54,8 +57,6 @@ module.exports = function cabinet(options) {
   return result;
 };
 
-module.exports.supportedFileExtensions = Object.keys(defaultLookups);
-
 /**
  * Register a custom lookup resolver for a file extension
  *
@@ -64,40 +65,26 @@ module.exports.supportedFileExtensions = Object.keys(defaultLookups);
  */
 module.exports.register = function(extension, lookupStrategy) {
   defaultLookups[extension] = lookupStrategy;
-
-  if (this.supportedFileExtensions.indexOf(extension) === -1) {
-    this.supportedFileExtensions.push(extension);
-  }
 };
 
 /**
  * Exposed for testing
  *
- * @param  {Object} options
- * @param  {String} options.config
- * @param  {String} options.webpackConfig
- * @param  {String} options.filename
- * @param  {Object} options.ast
+ * @param  {String} config
+ * @param  {String} webpackConfig
+ * @param  {String} filename
  * @return {String}
  */
-module.exports._getJSType = function(options) {
-  options = options || {};
-
-  if (options.config) {
+module.exports._getJSType = function(config, webpackConfig, filename) {
+  if (config) {
     return 'amd';
   }
 
-  if (options.webpackConfig) {
+  if (webpackConfig) {
     return 'webpack';
   }
 
-  if (options.ast) {
-    debug('reusing the given ast');
-    return getModuleType.fromSource(options.ast);
-  }
-
-  debug('using the filename to find the module type');
-  return getModuleType.sync(options.filename);
+  return getModuleType.sync(filename);
 };
 
 /**
@@ -105,19 +92,11 @@ module.exports._getJSType = function(options) {
  * @param  {String} partial
  * @param  {String} filename
  * @param  {String} directory
- * @param  {String} [config]
- * @param  {String} [webpackConfig]
- * @param  {String} [configPath]
- * @param  {Object} [ast]
+ * @param  {String} config
  * @return {String}
  */
-function jsLookup(partial, filename, directory, config, webpackConfig, configPath, ast) {
-  var type = module.exports._getJSType({
-    config: config,
-    webpackConfig: webpackConfig,
-    filename: filename,
-    ast: ast
-  });
+function jsLookup(partial, filename, directory, config, webpackConfig, configPath) {
+  var type = module.exports._getJSType(config, webpackConfig, filename);
 
   switch (type) {
     case 'amd':

--- a/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/index.js
+++ b/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/index.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-unused-vars */
+'use strict';
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+module.exports = Object.assign || function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (Object.getOwnPropertySymbols) {
+			symbols = Object.getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};

--- a/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/license
+++ b/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/package.json
+++ b/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/package.json
@@ -1,0 +1,113 @@
+{
+  "_args": [
+    [
+      {
+        "raw": "object-assign@~4.0.1",
+        "scope": null,
+        "escapedName": "object-assign",
+        "name": "object-assign",
+        "rawSpec": "~4.0.1",
+        "spec": ">=4.0.1 <4.1.0",
+        "type": "range"
+      },
+      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/app-root/node_modules/filing-cabinet"
+    ]
+  ],
+  "_from": "object-assign@>=4.0.1 <4.1.0",
+  "_id": "object-assign@4.0.1",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/app-root/filing-cabinet/object-assign",
+  "_nodeVersion": "3.0.0",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "_npmVersion": "2.13.3",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "object-assign@~4.0.1",
+    "scope": null,
+    "escapedName": "object-assign",
+    "name": "object-assign",
+    "rawSpec": "~4.0.1",
+    "spec": ">=4.0.1 <4.1.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "/app-root/filing-cabinet"
+  ],
+  "_resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+  "_shasum": "99504456c3598b5cad4fc59c26e8a9bb107fe0bd",
+  "_shrinkwrap": null,
+  "_spec": "object-assign@~4.0.1",
+  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/app-root/node_modules/filing-cabinet",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/object-assign/issues"
+  },
+  "dependencies": {},
+  "description": "ES6 Object.assign() ponyfill",
+  "devDependencies": {
+    "lodash": "^3.10.1",
+    "matcha": "^0.6.0",
+    "mocha": "*",
+    "xo": "*"
+  },
+  "directories": {},
+  "dist": {
+    "shasum": "99504456c3598b5cad4fc59c26e8a9bb107fe0bd",
+    "tarball": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "files": [
+    "index.js"
+  ],
+  "gitHead": "b0c40d37cbc43e89ad3326a9bad4c6b3133ba6d3",
+  "homepage": "https://github.com/sindresorhus/object-assign#readme",
+  "keywords": [
+    "object",
+    "assign",
+    "extend",
+    "properties",
+    "es6",
+    "ecmascript",
+    "harmony",
+    "ponyfill",
+    "prollyfill",
+    "polyfill",
+    "shim",
+    "browser"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "name": "object-assign",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/object-assign.git"
+  },
+  "scripts": {
+    "bench": "matcha bench.js",
+    "test": "xo && mocha"
+  },
+  "version": "4.0.1",
+  "xo": {
+    "envs": [
+      "node",
+      "mocha"
+    ]
+  }
+}

--- a/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/readme.md
+++ b/node_modules/app-root/node_modules/filing-cabinet/node_modules/object-assign/readme.md
@@ -1,0 +1,51 @@
+# object-assign [![Build Status](https://travis-ci.org/sindresorhus/object-assign.svg?branch=master)](https://travis-ci.org/sindresorhus/object-assign)
+
+> ES6 [`Object.assign()`](http://www.2ality.com/2014/01/object-assign.html) ponyfill
+
+> Ponyfill: A polyfill that doesn't overwrite the native method
+
+
+## Install
+
+```sh
+$ npm install --save object-assign
+```
+
+
+## Usage
+
+```js
+var objectAssign = require('object-assign');
+
+objectAssign({foo: 0}, {bar: 1});
+//=> {foo: 0, bar: 1}
+
+// multiple sources
+objectAssign({foo: 0}, {bar: 1}, {baz: 2});
+//=> {foo: 0, bar: 1, baz: 2}
+
+// overwrites equal keys
+objectAssign({foo: 0}, {foo: 1}, {foo: 2});
+//=> {foo: 2}
+
+// ignores null and undefined sources
+objectAssign({foo: 0}, null, {bar: 1}, undefined);
+//=> {foo: 0, bar: 1}
+```
+
+
+## API
+
+### objectAssign(target, source, [source, ...])
+
+Assigns enumerable own properties of `source` objects to the `target` object and returns the `target` object. Additional `source` objects will overwrite previous ones.
+
+
+## Resources
+
+- [ES6 spec - Object.assign](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign)
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/app-root/node_modules/filing-cabinet/package.json
+++ b/node_modules/app-root/node_modules/filing-cabinet/package.json
@@ -2,51 +2,50 @@
   "_args": [
     [
       {
-        "raw": "filing-cabinet@~1.4.0",
+        "raw": "filing-cabinet@~1.2.3",
         "scope": null,
         "escapedName": "filing-cabinet",
         "name": "filing-cabinet",
-        "rawSpec": "~1.4.0",
-        "spec": ">=1.4.0 <1.5.0",
+        "rawSpec": "~1.2.3",
+        "spec": ">=1.2.3 <1.3.0",
         "type": "range"
       },
-      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend"
+      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/app-root"
     ]
   ],
-  "_from": "filing-cabinet@>=1.4.0 <1.5.0",
-  "_id": "filing-cabinet@1.4.0",
+  "_from": "filing-cabinet@>=1.2.3 <1.3.0",
+  "_id": "filing-cabinet@1.2.11",
   "_inCache": true,
   "_installable": true,
-  "_location": "/filing-cabinet",
-  "_nodeVersion": "6.3.1",
+  "_location": "/app-root/filing-cabinet",
+  "_nodeVersion": "0.12.6",
   "_npmOperationalInternal": {
     "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/filing-cabinet-1.4.0.tgz_1471118028651_0.43448022776283324"
+    "tmp": "tmp/filing-cabinet-1.2.11.tgz_1468455188189_0.37159491633065045"
   },
   "_npmUser": {
     "name": "mrjoelkemp",
     "email": "joel@mrjoelkemp.com"
   },
-  "_npmVersion": "3.10.3",
+  "_npmVersion": "3.8.0",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "filing-cabinet@~1.4.0",
+    "raw": "filing-cabinet@~1.2.3",
     "scope": null,
     "escapedName": "filing-cabinet",
     "name": "filing-cabinet",
-    "rawSpec": "~1.4.0",
-    "spec": ">=1.4.0 <1.5.0",
+    "rawSpec": "~1.2.3",
+    "spec": ">=1.2.3 <1.3.0",
     "type": "range"
   },
   "_requiredBy": [
-    "/dependents",
-    "/dependents-editor-backend"
+    "/app-root"
   ],
-  "_resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.4.0.tgz",
-  "_shasum": "706e320651be278afde35db7e5e34e84c436969b",
+  "_resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.2.11.tgz",
+  "_shasum": "2c276f55aa97d9c663588299b696718dca2cebdd",
   "_shrinkwrap": null,
-  "_spec": "filing-cabinet@~1.4.0",
-  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend",
+  "_spec": "filing-cabinet@~1.2.3",
+  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/app-root",
   "author": {
     "name": "Joel Kemp",
     "email": "joel@mrjoelkemp.com",
@@ -65,13 +64,13 @@
     "enhanced-resolve": "~2.2.2",
     "file-exists": "~1.0.0",
     "is-relative-path": "~1.0.0",
-    "module-definition": "^2.2.3",
-    "module-lookup-amd": "^4.0.2",
+    "module-definition": "~2.2.3",
+    "module-lookup-amd": "~4.0.2",
     "object-assign": "~4.0.1",
     "resolve": "~1.1.7",
-    "resolve-dependency-path": "^1.0.2",
-    "sass-lookup": "^1.0.2",
-    "stylus-lookup": "^1.0.1"
+    "resolve-dependency-path": "~1.0.2",
+    "sass-lookup": "~1.0.2",
+    "stylus-lookup": "~1.0.0"
   },
   "description": "Find files based on partial paths",
   "devDependencies": {
@@ -79,16 +78,16 @@
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "~2.2.5",
-    "mock-fs": "~3.11.0",
+    "mock-fs": "~3.7.0",
     "rewire": "~2.3.4",
     "sinon": "~1.15.4"
   },
   "directories": {},
   "dist": {
-    "shasum": "706e320651be278afde35db7e5e34e84c436969b",
-    "tarball": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.4.0.tgz"
+    "shasum": "2c276f55aa97d9c663588299b696718dca2cebdd",
+    "tarball": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.2.11.tgz"
   },
-  "gitHead": "c3c57a80a6bc60a490998c2169181fbc02fcdd21",
+  "gitHead": "ecb9ceefb34d281f44df461831b33c0acab0e992",
   "homepage": "https://github.com/mrjoelkemp/node-filing-cabinet",
   "keywords": [
     "lookup",
@@ -119,5 +118,5 @@
   "scripts": {
     "test": "jscs index.js test/test.js && ./node_modules/.bin/mocha --compilers js:babel/register test/test.js"
   },
-  "version": "1.4.0"
+  "version": "1.2.11"
 }

--- a/node_modules/app-root/node_modules/filing-cabinet/readme.md
+++ b/node_modules/app-root/node_modules/filing-cabinet/readme.md
@@ -2,7 +2,7 @@
 
 > Look up a filename based on a partial path
 
-`npm install --save filing-cabinet`
+`npm install filing-cabinet`
 
 ### Usage
 
@@ -14,23 +14,17 @@ var result = cabinet({
   partial: 'somePartialPath',
   directory: 'path/to/all/files',
   filename: 'path/to/parent/file',
-  ast: {}, // an optional AST representation of `filename`
-  // Only for JavaScript files
   config: 'path/to/requirejs/config',
   webpackConfig: 'path/to/webpack/config'
 });
 
-console.log(result); // /absolute/path/to/somePartialPath
+console.log(result); // absolute/path/to/somePartialPath
 ```
 
 * `partial`: the dependency path
  * This could be in any of the registered languages
-* `directory`: the path to all files
-* `filename`: the path to the file containing the `partial`
-* `ast`: (optional) the parsed AST for `filename`.
- * Useful optimization for avoiding a parse of filename
-* `config`: (optional) requirejs config for resolving aliased JavaScript modules
-* `webpackConfig`: (optional) webpack config for resolving aliased JavaScript modules
+* `config`: (optional) requirejs config for resolving aliased modules
+* `webpackConfig`: (optional) webpack config for resolving aliased modules
 
 ### Registered languages
 

--- a/node_modules/dependency-tree/node_modules/filing-cabinet/.npmignore
+++ b/node_modules/dependency-tree/node_modules/filing-cabinet/.npmignore
@@ -1,0 +1,8 @@
+test
+.gitignore
+.jscsrc
+.jshintrc
+.travis.yml
+.deprc
+readme.md
+webpack.config.js

--- a/node_modules/dependency-tree/node_modules/filing-cabinet/bin/cli.js
+++ b/node_modules/dependency-tree/node_modules/filing-cabinet/bin/cli.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var program = require('commander');
+var cabinet = require('../');
+
+program
+  .version(require('../package.json').version)
+  .usage('[options] <path>')
+  .option('-d, --directory <path>', 'root of all files')
+  .option('-c, --config [path]', 'location of a RequireJS config file for AMD')
+  .option('-w, --webpack-config [path]', 'location of a webpack config file')
+  .option('-f, --filename [path]', 'file containing the dependency')
+  .parse(process.argv);
+
+var filename = program.filename;
+var directory = program.directory;
+var config = program.config;
+var webpackConfig = program.webpackConfig;
+var dep = program.args[0];
+
+var result = cabinet({
+  partial: dep,
+  filename: filename,
+  directory: directory,
+  config: config,
+  webpackConfig: webpackConfig
+});
+
+console.log(result);

--- a/node_modules/dependency-tree/node_modules/filing-cabinet/index.js
+++ b/node_modules/dependency-tree/node_modules/filing-cabinet/index.js
@@ -11,25 +11,28 @@ var sassLookup = require('sass-lookup');
 var resolveDependencyPath = require('resolve-dependency-path');
 
 var appModulePath = require('app-module-path');
+var assign = require('object-assign');
 var fileExists = require('file-exists');
 
 var webpackResolve = require('enhanced-resolve');
 
-var defaultLookups = {
-  '.js': jsLookup,
-  '.scss': sassLookup,
-  '.sass': sassLookup,
-  '.styl': stylusLookup
-};
+var defaultLookups = {};
 
-module.exports = function cabinet(options) {
+module.exports = function(options) {
+  // Lazy binding for test stubbing purposes
+  assign(defaultLookups, {
+    '.js': jsLookup,
+    '.scss': sassLookup,
+    '.sass': sassLookup,
+    '.styl': stylusLookup
+  });
+
   var partial = options.partial;
   var filename = options.filename;
   var directory = options.directory;
   var config = options.config;
   var webpackConfig = options.webpackConfig;
   var configPath = options.configPath;
-  var ast = options.ast;
 
   var ext = path.extname(filename);
 
@@ -43,7 +46,7 @@ module.exports = function cabinet(options) {
   debug('found a resolver for ' + ext);
 
   // TODO: Change all resolvers to accept an options argument
-  var result = resolver(partial, filename, directory, config, webpackConfig, configPath, ast);
+  var result = resolver(partial, filename, directory, config, webpackConfig, configPath);
 
   // TODO: Remove. All resolvers should provide a complete path
   if (result && !path.extname(result)) {
@@ -54,8 +57,6 @@ module.exports = function cabinet(options) {
   return result;
 };
 
-module.exports.supportedFileExtensions = Object.keys(defaultLookups);
-
 /**
  * Register a custom lookup resolver for a file extension
  *
@@ -64,40 +65,26 @@ module.exports.supportedFileExtensions = Object.keys(defaultLookups);
  */
 module.exports.register = function(extension, lookupStrategy) {
   defaultLookups[extension] = lookupStrategy;
-
-  if (this.supportedFileExtensions.indexOf(extension) === -1) {
-    this.supportedFileExtensions.push(extension);
-  }
 };
 
 /**
  * Exposed for testing
  *
- * @param  {Object} options
- * @param  {String} options.config
- * @param  {String} options.webpackConfig
- * @param  {String} options.filename
- * @param  {Object} options.ast
+ * @param  {String} config
+ * @param  {String} webpackConfig
+ * @param  {String} filename
  * @return {String}
  */
-module.exports._getJSType = function(options) {
-  options = options || {};
-
-  if (options.config) {
+module.exports._getJSType = function(config, webpackConfig, filename) {
+  if (config) {
     return 'amd';
   }
 
-  if (options.webpackConfig) {
+  if (webpackConfig) {
     return 'webpack';
   }
 
-  if (options.ast) {
-    debug('reusing the given ast');
-    return getModuleType.fromSource(options.ast);
-  }
-
-  debug('using the filename to find the module type');
-  return getModuleType.sync(options.filename);
+  return getModuleType.sync(filename);
 };
 
 /**
@@ -105,19 +92,11 @@ module.exports._getJSType = function(options) {
  * @param  {String} partial
  * @param  {String} filename
  * @param  {String} directory
- * @param  {String} [config]
- * @param  {String} [webpackConfig]
- * @param  {String} [configPath]
- * @param  {Object} [ast]
+ * @param  {String} config
  * @return {String}
  */
-function jsLookup(partial, filename, directory, config, webpackConfig, configPath, ast) {
-  var type = module.exports._getJSType({
-    config: config,
-    webpackConfig: webpackConfig,
-    filename: filename,
-    ast: ast
-  });
+function jsLookup(partial, filename, directory, config, webpackConfig, configPath) {
+  var type = module.exports._getJSType(config, webpackConfig, filename);
 
   switch (type) {
     case 'amd':

--- a/node_modules/dependency-tree/node_modules/filing-cabinet/package.json
+++ b/node_modules/dependency-tree/node_modules/filing-cabinet/package.json
@@ -2,51 +2,50 @@
   "_args": [
     [
       {
-        "raw": "filing-cabinet@~1.4.0",
+        "raw": "filing-cabinet@~1.2.6",
         "scope": null,
         "escapedName": "filing-cabinet",
         "name": "filing-cabinet",
-        "rawSpec": "~1.4.0",
-        "spec": ">=1.4.0 <1.5.0",
+        "rawSpec": "~1.2.6",
+        "spec": ">=1.2.6 <1.3.0",
         "type": "range"
       },
-      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend"
+      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependency-tree"
     ]
   ],
-  "_from": "filing-cabinet@>=1.4.0 <1.5.0",
-  "_id": "filing-cabinet@1.4.0",
+  "_from": "filing-cabinet@>=1.2.6 <1.3.0",
+  "_id": "filing-cabinet@1.2.11",
   "_inCache": true,
   "_installable": true,
-  "_location": "/filing-cabinet",
-  "_nodeVersion": "6.3.1",
+  "_location": "/dependency-tree/filing-cabinet",
+  "_nodeVersion": "0.12.6",
   "_npmOperationalInternal": {
     "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/filing-cabinet-1.4.0.tgz_1471118028651_0.43448022776283324"
+    "tmp": "tmp/filing-cabinet-1.2.11.tgz_1468455188189_0.37159491633065045"
   },
   "_npmUser": {
     "name": "mrjoelkemp",
     "email": "joel@mrjoelkemp.com"
   },
-  "_npmVersion": "3.10.3",
+  "_npmVersion": "3.8.0",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "filing-cabinet@~1.4.0",
+    "raw": "filing-cabinet@~1.2.6",
     "scope": null,
     "escapedName": "filing-cabinet",
     "name": "filing-cabinet",
-    "rawSpec": "~1.4.0",
-    "spec": ">=1.4.0 <1.5.0",
+    "rawSpec": "~1.2.6",
+    "spec": ">=1.2.6 <1.3.0",
     "type": "range"
   },
   "_requiredBy": [
-    "/dependents",
-    "/dependents-editor-backend"
+    "/dependency-tree"
   ],
-  "_resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.4.0.tgz",
-  "_shasum": "706e320651be278afde35db7e5e34e84c436969b",
+  "_resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.2.11.tgz",
+  "_shasum": "2c276f55aa97d9c663588299b696718dca2cebdd",
   "_shrinkwrap": null,
-  "_spec": "filing-cabinet@~1.4.0",
-  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend",
+  "_spec": "filing-cabinet@~1.2.6",
+  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependency-tree",
   "author": {
     "name": "Joel Kemp",
     "email": "joel@mrjoelkemp.com",
@@ -65,13 +64,13 @@
     "enhanced-resolve": "~2.2.2",
     "file-exists": "~1.0.0",
     "is-relative-path": "~1.0.0",
-    "module-definition": "^2.2.3",
-    "module-lookup-amd": "^4.0.2",
+    "module-definition": "~2.2.3",
+    "module-lookup-amd": "~4.0.2",
     "object-assign": "~4.0.1",
     "resolve": "~1.1.7",
-    "resolve-dependency-path": "^1.0.2",
-    "sass-lookup": "^1.0.2",
-    "stylus-lookup": "^1.0.1"
+    "resolve-dependency-path": "~1.0.2",
+    "sass-lookup": "~1.0.2",
+    "stylus-lookup": "~1.0.0"
   },
   "description": "Find files based on partial paths",
   "devDependencies": {
@@ -79,16 +78,16 @@
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "~2.2.5",
-    "mock-fs": "~3.11.0",
+    "mock-fs": "~3.7.0",
     "rewire": "~2.3.4",
     "sinon": "~1.15.4"
   },
   "directories": {},
   "dist": {
-    "shasum": "706e320651be278afde35db7e5e34e84c436969b",
-    "tarball": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.4.0.tgz"
+    "shasum": "2c276f55aa97d9c663588299b696718dca2cebdd",
+    "tarball": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.2.11.tgz"
   },
-  "gitHead": "c3c57a80a6bc60a490998c2169181fbc02fcdd21",
+  "gitHead": "ecb9ceefb34d281f44df461831b33c0acab0e992",
   "homepage": "https://github.com/mrjoelkemp/node-filing-cabinet",
   "keywords": [
     "lookup",
@@ -119,5 +118,5 @@
   "scripts": {
     "test": "jscs index.js test/test.js && ./node_modules/.bin/mocha --compilers js:babel/register test/test.js"
   },
-  "version": "1.4.0"
+  "version": "1.2.11"
 }

--- a/node_modules/dependency-tree/node_modules/filing-cabinet/readme.md
+++ b/node_modules/dependency-tree/node_modules/filing-cabinet/readme.md
@@ -2,7 +2,7 @@
 
 > Look up a filename based on a partial path
 
-`npm install --save filing-cabinet`
+`npm install filing-cabinet`
 
 ### Usage
 
@@ -14,23 +14,17 @@ var result = cabinet({
   partial: 'somePartialPath',
   directory: 'path/to/all/files',
   filename: 'path/to/parent/file',
-  ast: {}, // an optional AST representation of `filename`
-  // Only for JavaScript files
   config: 'path/to/requirejs/config',
   webpackConfig: 'path/to/webpack/config'
 });
 
-console.log(result); // /absolute/path/to/somePartialPath
+console.log(result); // absolute/path/to/somePartialPath
 ```
 
 * `partial`: the dependency path
  * This could be in any of the registered languages
-* `directory`: the path to all files
-* `filename`: the path to the file containing the `partial`
-* `ast`: (optional) the parsed AST for `filename`.
- * Useful optimization for avoiding a parse of filename
-* `config`: (optional) requirejs config for resolving aliased JavaScript modules
-* `webpackConfig`: (optional) webpack config for resolving aliased JavaScript modules
+* `config`: (optional) requirejs config for resolving aliased modules
+* `webpackConfig`: (optional) webpack config for resolving aliased modules
 
 ### Registered languages
 

--- a/node_modules/dependency-tree/node_modules/object-assign/index.js
+++ b/node_modules/dependency-tree/node_modules/object-assign/index.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-unused-vars */
+'use strict';
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+module.exports = Object.assign || function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (Object.getOwnPropertySymbols) {
+			symbols = Object.getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};

--- a/node_modules/dependency-tree/node_modules/object-assign/license
+++ b/node_modules/dependency-tree/node_modules/object-assign/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/node_modules/dependency-tree/node_modules/object-assign/package.json
+++ b/node_modules/dependency-tree/node_modules/object-assign/package.json
@@ -1,0 +1,113 @@
+{
+  "_args": [
+    [
+      {
+        "raw": "object-assign@~4.0.1",
+        "scope": null,
+        "escapedName": "object-assign",
+        "name": "object-assign",
+        "rawSpec": "~4.0.1",
+        "spec": ">=4.0.1 <4.1.0",
+        "type": "range"
+      },
+      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependency-tree/node_modules/filing-cabinet"
+    ]
+  ],
+  "_from": "object-assign@>=4.0.1 <4.1.0",
+  "_id": "object-assign@4.0.1",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/dependency-tree/object-assign",
+  "_nodeVersion": "3.0.0",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "_npmVersion": "2.13.3",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "object-assign@~4.0.1",
+    "scope": null,
+    "escapedName": "object-assign",
+    "name": "object-assign",
+    "rawSpec": "~4.0.1",
+    "spec": ">=4.0.1 <4.1.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "/dependency-tree/filing-cabinet"
+  ],
+  "_resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+  "_shasum": "99504456c3598b5cad4fc59c26e8a9bb107fe0bd",
+  "_shrinkwrap": null,
+  "_spec": "object-assign@~4.0.1",
+  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependency-tree/node_modules/filing-cabinet",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/object-assign/issues"
+  },
+  "dependencies": {},
+  "description": "ES6 Object.assign() ponyfill",
+  "devDependencies": {
+    "lodash": "^3.10.1",
+    "matcha": "^0.6.0",
+    "mocha": "*",
+    "xo": "*"
+  },
+  "directories": {},
+  "dist": {
+    "shasum": "99504456c3598b5cad4fc59c26e8a9bb107fe0bd",
+    "tarball": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "files": [
+    "index.js"
+  ],
+  "gitHead": "b0c40d37cbc43e89ad3326a9bad4c6b3133ba6d3",
+  "homepage": "https://github.com/sindresorhus/object-assign#readme",
+  "keywords": [
+    "object",
+    "assign",
+    "extend",
+    "properties",
+    "es6",
+    "ecmascript",
+    "harmony",
+    "ponyfill",
+    "prollyfill",
+    "polyfill",
+    "shim",
+    "browser"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "name": "object-assign",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/object-assign.git"
+  },
+  "scripts": {
+    "bench": "matcha bench.js",
+    "test": "xo && mocha"
+  },
+  "version": "4.0.1",
+  "xo": {
+    "envs": [
+      "node",
+      "mocha"
+    ]
+  }
+}

--- a/node_modules/dependency-tree/node_modules/object-assign/readme.md
+++ b/node_modules/dependency-tree/node_modules/object-assign/readme.md
@@ -1,0 +1,51 @@
+# object-assign [![Build Status](https://travis-ci.org/sindresorhus/object-assign.svg?branch=master)](https://travis-ci.org/sindresorhus/object-assign)
+
+> ES6 [`Object.assign()`](http://www.2ality.com/2014/01/object-assign.html) ponyfill
+
+> Ponyfill: A polyfill that doesn't overwrite the native method
+
+
+## Install
+
+```sh
+$ npm install --save object-assign
+```
+
+
+## Usage
+
+```js
+var objectAssign = require('object-assign');
+
+objectAssign({foo: 0}, {bar: 1});
+//=> {foo: 0, bar: 1}
+
+// multiple sources
+objectAssign({foo: 0}, {bar: 1}, {baz: 2});
+//=> {foo: 0, bar: 1, baz: 2}
+
+// overwrites equal keys
+objectAssign({foo: 0}, {foo: 1}, {foo: 2});
+//=> {foo: 2}
+
+// ignores null and undefined sources
+objectAssign({foo: 0}, null, {bar: 1}, undefined);
+//=> {foo: 0, bar: 1}
+```
+
+
+## API
+
+### objectAssign(target, source, [source, ...])
+
+Assigns enumerable own properties of `source` objects to the `target` object and returns the `target` object. Additional `source` objects will overwrite previous ones.
+
+
+## Resources
+
+- [ES6 spec - Object.assign](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign)
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/dependents-editor-backend/package.json
+++ b/node_modules/dependents-editor-backend/package.json
@@ -2,49 +2,49 @@
   "_args": [
     [
       {
-        "raw": "dependents-editor-backend@~1.14.0",
+        "raw": "dependents-editor-backend@~1.15.0",
         "scope": null,
         "escapedName": "dependents-editor-backend",
         "name": "dependents-editor-backend",
-        "rawSpec": "~1.14.0",
-        "spec": ">=1.14.0 <1.15.0",
+        "rawSpec": "~1.15.0",
+        "spec": ">=1.15.0 <1.16.0",
         "type": "range"
       },
       "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents"
     ]
   ],
-  "_from": "dependents-editor-backend@>=1.14.0 <1.15.0",
-  "_id": "dependents-editor-backend@1.14.0",
+  "_from": "dependents-editor-backend@>=1.15.0 <1.16.0",
+  "_id": "dependents-editor-backend@1.15.0",
   "_inCache": true,
   "_installable": true,
   "_location": "/dependents-editor-backend",
-  "_nodeVersion": "0.12.6",
+  "_nodeVersion": "6.3.1",
   "_npmOperationalInternal": {
-    "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/dependents-editor-backend-1.14.0.tgz_1468457524900_0.8523250790312886"
+    "host": "packages-16-east.internal.npmjs.com",
+    "tmp": "tmp/dependents-editor-backend-1.15.0.tgz_1471225441746_0.7346350287552923"
   },
   "_npmUser": {
     "name": "mrjoelkemp",
     "email": "joel@mrjoelkemp.com"
   },
-  "_npmVersion": "3.8.0",
+  "_npmVersion": "3.10.3",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "dependents-editor-backend@~1.14.0",
+    "raw": "dependents-editor-backend@~1.15.0",
     "scope": null,
     "escapedName": "dependents-editor-backend",
     "name": "dependents-editor-backend",
-    "rawSpec": "~1.14.0",
-    "spec": ">=1.14.0 <1.15.0",
+    "rawSpec": "~1.15.0",
+    "spec": ">=1.15.0 <1.16.0",
     "type": "range"
   },
   "_requiredBy": [
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/dependents-editor-backend/-/dependents-editor-backend-1.14.0.tgz",
-  "_shasum": "e0d6bb38678271648a0478be3859c7995a1bcea3",
+  "_resolved": "https://registry.npmjs.org/dependents-editor-backend/-/dependents-editor-backend-1.15.0.tgz",
+  "_shasum": "732d14e3f535b7dcd51e073a8a86feffcadc43a9",
   "_shrinkwrap": null,
-  "_spec": "dependents-editor-backend@~1.14.0",
+  "_spec": "dependents-editor-backend@~1.15.0",
   "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents",
   "author": {
     "name": "Joel Kemp",
@@ -62,8 +62,8 @@
     "commander": "~2.8.1",
     "debug": "~2.2.0",
     "dependency-tree": "~5.3.0",
-    "dependents": "~3.2.0",
-    "filing-cabinet": "~1.2.10",
+    "dependents": "~3.3.0",
+    "filing-cabinet": "~1.4.0",
     "is-plain-object": "~2.0.1",
     "mixpanel": "~0.4.0",
     "node-tictoc": "~1.3.0",
@@ -86,10 +86,10 @@
   },
   "directories": {},
   "dist": {
-    "shasum": "e0d6bb38678271648a0478be3859c7995a1bcea3",
-    "tarball": "https://registry.npmjs.org/dependents-editor-backend/-/dependents-editor-backend-1.14.0.tgz"
+    "shasum": "732d14e3f535b7dcd51e073a8a86feffcadc43a9",
+    "tarball": "https://registry.npmjs.org/dependents-editor-backend/-/dependents-editor-backend-1.15.0.tgz"
   },
-  "gitHead": "e16a4bc0935e9d84aaca0c82962091287810b50c",
+  "gitHead": "f4ac9ae9c296232cafd8d6a3efe67a811274043b",
   "homepage": "https://github.com/mrjoelkemp/node-dependents-editor-backend#readme",
   "keywords": [
     "Dependents",
@@ -115,5 +115,5 @@
     "debug-test": "DEBUG=*,-mocha:*,-babel,-parse npm test",
     "test": "jscs lib test/lib test/features bin && jshint && ./node_modules/.bin/mocha --compilers js:babel/register 'test/lib/**/*.js' 'test/features/**/*.js'"
   },
-  "version": "1.14.0"
+  "version": "1.15.0"
 }

--- a/node_modules/dependents/lib/computeDependents.js
+++ b/node_modules/dependents/lib/computeDependents.js
@@ -21,15 +21,16 @@ module.exports = function(options) {
   dependents[filename] = {};
 
   // Register the current file as dependent on each dependency
-  var dependencies = getDependencies(filename);
+  var data = getDependencies(filename);
 
-  debug('' + dependencies.length + ' dependencies for ' + filename.replace(new RegExp(directory + '/?'), ''));
+  debug('' + data.dependencies.length + ' dependencies for ' + filename.replace(new RegExp(directory + '/?'), ''));
 
-  dependencies.forEach(function(dep) {
+  data.dependencies.forEach(function(dep) {
     debug('before cabinet lookup: ' + dep);
 
     var result = cabinet({
       partial: dep,
+      ast: data.ast,
       filename: filename,
       directory: directory,
       config: config,
@@ -56,11 +57,20 @@ module.exports = function(options) {
  * @return {String[]}
  */
 function getDependencies(filename) {
+  var result = {
+    ast: null,
+    dependencies: [],
+  };
+
   try {
-    return precinct.paperwork(filename, {
+    result.dependencies = precinct.paperwork(filename, {
       includeCore: false
     });
+
+    result.ast = precinct.ast;
+
+    return result;
   } catch (e) {
-    return [];
+    return result;
   }
 }

--- a/node_modules/dependents/package.json
+++ b/node_modules/dependents/package.json
@@ -2,50 +2,50 @@
   "_args": [
     [
       {
-        "raw": "dependents@~3.2.0",
+        "raw": "dependents@~3.3.0",
         "scope": null,
         "escapedName": "dependents",
         "name": "dependents",
-        "rawSpec": "~3.2.0",
-        "spec": ">=3.2.0 <3.3.0",
+        "rawSpec": "~3.3.0",
+        "spec": ">=3.3.0 <3.4.0",
         "type": "range"
       },
       "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend"
     ]
   ],
-  "_from": "dependents@>=3.2.0 <3.3.0",
-  "_id": "dependents@3.2.0",
+  "_from": "dependents@>=3.3.0 <3.4.0",
+  "_id": "dependents@3.3.0",
   "_inCache": true,
   "_installable": true,
   "_location": "/dependents",
-  "_nodeVersion": "0.12.6",
+  "_nodeVersion": "6.3.1",
   "_npmOperationalInternal": {
     "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/dependents-3.2.0.tgz_1468202308498_0.3319234100636095"
+    "tmp": "tmp/dependents-3.3.0.tgz_1471225081172_0.8404448488727212"
   },
   "_npmUser": {
     "name": "mrjoelkemp",
     "email": "joel@mrjoelkemp.com"
   },
-  "_npmVersion": "3.8.0",
+  "_npmVersion": "3.10.3",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "dependents@~3.2.0",
+    "raw": "dependents@~3.3.0",
     "scope": null,
     "escapedName": "dependents",
     "name": "dependents",
-    "rawSpec": "~3.2.0",
-    "spec": ">=3.2.0 <3.3.0",
+    "rawSpec": "~3.3.0",
+    "spec": ">=3.3.0 <3.4.0",
     "type": "range"
   },
   "_requiredBy": [
     "/callers",
     "/dependents-editor-backend"
   ],
-  "_resolved": "https://registry.npmjs.org/dependents/-/dependents-3.2.0.tgz",
-  "_shasum": "43c3c5cfe00d7d9d2b2910d43487771c6a6df001",
+  "_resolved": "https://registry.npmjs.org/dependents/-/dependents-3.3.0.tgz",
+  "_shasum": "4c1f45c4207e3d51cd32bdf31e2416465bcfada0",
   "_shrinkwrap": null,
-  "_spec": "dependents@~3.2.0",
+  "_spec": "dependents@~3.3.0",
   "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend",
   "author": {
     "name": "Joel Kemp",
@@ -61,9 +61,9 @@
     "commander": "^2.5.1",
     "debug": "^2.2.0",
     "extend": "^2.0.1",
-    "filing-cabinet": "~1.2.6",
+    "filing-cabinet": "^1.4.0",
     "glob-all": "~3.0.1",
-    "precinct": "^3.0.0",
+    "precinct": "^3.1.1",
     "q": "^1.0.1",
     "requirejs-config-file": "^2.0.0"
   },
@@ -80,10 +80,10 @@
   },
   "directories": {},
   "dist": {
-    "shasum": "43c3c5cfe00d7d9d2b2910d43487771c6a6df001",
-    "tarball": "https://registry.npmjs.org/dependents/-/dependents-3.2.0.tgz"
+    "shasum": "4c1f45c4207e3d51cd32bdf31e2416465bcfada0",
+    "tarball": "https://registry.npmjs.org/dependents/-/dependents-3.3.0.tgz"
   },
-  "gitHead": "9f471597db12ef6afe2346d5f00c3cc346bc43fc",
+  "gitHead": "fef50e6cd63d4c54a73406f0e78dcd368fe42a95",
   "homepage": "https://github.com/mrjoelkemp/node-dependents",
   "keywords": [
     "dependents",
@@ -132,5 +132,5 @@
       "simple"
     ]
   },
-  "version": "3.2.0"
+  "version": "3.3.0"
 }

--- a/node_modules/tree-pic/node_modules/filing-cabinet/.npmignore
+++ b/node_modules/tree-pic/node_modules/filing-cabinet/.npmignore
@@ -1,0 +1,8 @@
+test
+.gitignore
+.jscsrc
+.jshintrc
+.travis.yml
+.deprc
+readme.md
+webpack.config.js

--- a/node_modules/tree-pic/node_modules/filing-cabinet/bin/cli.js
+++ b/node_modules/tree-pic/node_modules/filing-cabinet/bin/cli.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var program = require('commander');
+var cabinet = require('../');
+
+program
+  .version(require('../package.json').version)
+  .usage('[options] <path>')
+  .option('-d, --directory <path>', 'root of all files')
+  .option('-c, --config [path]', 'location of a RequireJS config file for AMD')
+  .option('-w, --webpack-config [path]', 'location of a webpack config file')
+  .option('-f, --filename [path]', 'file containing the dependency')
+  .parse(process.argv);
+
+var filename = program.filename;
+var directory = program.directory;
+var config = program.config;
+var webpackConfig = program.webpackConfig;
+var dep = program.args[0];
+
+var result = cabinet({
+  partial: dep,
+  filename: filename,
+  directory: directory,
+  config: config,
+  webpackConfig: webpackConfig
+});
+
+console.log(result);

--- a/node_modules/tree-pic/node_modules/filing-cabinet/index.js
+++ b/node_modules/tree-pic/node_modules/filing-cabinet/index.js
@@ -11,25 +11,28 @@ var sassLookup = require('sass-lookup');
 var resolveDependencyPath = require('resolve-dependency-path');
 
 var appModulePath = require('app-module-path');
+var assign = require('object-assign');
 var fileExists = require('file-exists');
 
 var webpackResolve = require('enhanced-resolve');
 
-var defaultLookups = {
-  '.js': jsLookup,
-  '.scss': sassLookup,
-  '.sass': sassLookup,
-  '.styl': stylusLookup
-};
+var defaultLookups = {};
 
-module.exports = function cabinet(options) {
+module.exports = function(options) {
+  // Lazy binding for test stubbing purposes
+  assign(defaultLookups, {
+    '.js': jsLookup,
+    '.scss': sassLookup,
+    '.sass': sassLookup,
+    '.styl': stylusLookup
+  });
+
   var partial = options.partial;
   var filename = options.filename;
   var directory = options.directory;
   var config = options.config;
   var webpackConfig = options.webpackConfig;
   var configPath = options.configPath;
-  var ast = options.ast;
 
   var ext = path.extname(filename);
 
@@ -43,7 +46,7 @@ module.exports = function cabinet(options) {
   debug('found a resolver for ' + ext);
 
   // TODO: Change all resolvers to accept an options argument
-  var result = resolver(partial, filename, directory, config, webpackConfig, configPath, ast);
+  var result = resolver(partial, filename, directory, config, webpackConfig, configPath);
 
   // TODO: Remove. All resolvers should provide a complete path
   if (result && !path.extname(result)) {
@@ -54,8 +57,6 @@ module.exports = function cabinet(options) {
   return result;
 };
 
-module.exports.supportedFileExtensions = Object.keys(defaultLookups);
-
 /**
  * Register a custom lookup resolver for a file extension
  *
@@ -64,40 +65,26 @@ module.exports.supportedFileExtensions = Object.keys(defaultLookups);
  */
 module.exports.register = function(extension, lookupStrategy) {
   defaultLookups[extension] = lookupStrategy;
-
-  if (this.supportedFileExtensions.indexOf(extension) === -1) {
-    this.supportedFileExtensions.push(extension);
-  }
 };
 
 /**
  * Exposed for testing
  *
- * @param  {Object} options
- * @param  {String} options.config
- * @param  {String} options.webpackConfig
- * @param  {String} options.filename
- * @param  {Object} options.ast
+ * @param  {String} config
+ * @param  {String} webpackConfig
+ * @param  {String} filename
  * @return {String}
  */
-module.exports._getJSType = function(options) {
-  options = options || {};
-
-  if (options.config) {
+module.exports._getJSType = function(config, webpackConfig, filename) {
+  if (config) {
     return 'amd';
   }
 
-  if (options.webpackConfig) {
+  if (webpackConfig) {
     return 'webpack';
   }
 
-  if (options.ast) {
-    debug('reusing the given ast');
-    return getModuleType.fromSource(options.ast);
-  }
-
-  debug('using the filename to find the module type');
-  return getModuleType.sync(options.filename);
+  return getModuleType.sync(filename);
 };
 
 /**
@@ -105,19 +92,11 @@ module.exports._getJSType = function(options) {
  * @param  {String} partial
  * @param  {String} filename
  * @param  {String} directory
- * @param  {String} [config]
- * @param  {String} [webpackConfig]
- * @param  {String} [configPath]
- * @param  {Object} [ast]
+ * @param  {String} config
  * @return {String}
  */
-function jsLookup(partial, filename, directory, config, webpackConfig, configPath, ast) {
-  var type = module.exports._getJSType({
-    config: config,
-    webpackConfig: webpackConfig,
-    filename: filename,
-    ast: ast
-  });
+function jsLookup(partial, filename, directory, config, webpackConfig, configPath) {
+  var type = module.exports._getJSType(config, webpackConfig, filename);
 
   switch (type) {
     case 'amd':

--- a/node_modules/tree-pic/node_modules/filing-cabinet/package.json
+++ b/node_modules/tree-pic/node_modules/filing-cabinet/package.json
@@ -2,51 +2,50 @@
   "_args": [
     [
       {
-        "raw": "filing-cabinet@~1.4.0",
+        "raw": "filing-cabinet@~1.2.11",
         "scope": null,
         "escapedName": "filing-cabinet",
         "name": "filing-cabinet",
-        "rawSpec": "~1.4.0",
-        "spec": ">=1.4.0 <1.5.0",
+        "rawSpec": "~1.2.11",
+        "spec": ">=1.2.11 <1.3.0",
         "type": "range"
       },
-      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend"
+      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/tree-pic/node_modules/dependency-tree"
     ]
   ],
-  "_from": "filing-cabinet@>=1.4.0 <1.5.0",
-  "_id": "filing-cabinet@1.4.0",
+  "_from": "filing-cabinet@>=1.2.11 <1.3.0",
+  "_id": "filing-cabinet@1.2.11",
   "_inCache": true,
   "_installable": true,
-  "_location": "/filing-cabinet",
-  "_nodeVersion": "6.3.1",
+  "_location": "/tree-pic/filing-cabinet",
+  "_nodeVersion": "0.12.6",
   "_npmOperationalInternal": {
     "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/filing-cabinet-1.4.0.tgz_1471118028651_0.43448022776283324"
+    "tmp": "tmp/filing-cabinet-1.2.11.tgz_1468455188189_0.37159491633065045"
   },
   "_npmUser": {
     "name": "mrjoelkemp",
     "email": "joel@mrjoelkemp.com"
   },
-  "_npmVersion": "3.10.3",
+  "_npmVersion": "3.8.0",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "filing-cabinet@~1.4.0",
+    "raw": "filing-cabinet@~1.2.11",
     "scope": null,
     "escapedName": "filing-cabinet",
     "name": "filing-cabinet",
-    "rawSpec": "~1.4.0",
-    "spec": ">=1.4.0 <1.5.0",
+    "rawSpec": "~1.2.11",
+    "spec": ">=1.2.11 <1.3.0",
     "type": "range"
   },
   "_requiredBy": [
-    "/dependents",
-    "/dependents-editor-backend"
+    "/tree-pic/dependency-tree"
   ],
-  "_resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.4.0.tgz",
-  "_shasum": "706e320651be278afde35db7e5e34e84c436969b",
+  "_resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.2.11.tgz",
+  "_shasum": "2c276f55aa97d9c663588299b696718dca2cebdd",
   "_shrinkwrap": null,
-  "_spec": "filing-cabinet@~1.4.0",
-  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/dependents-editor-backend",
+  "_spec": "filing-cabinet@~1.2.11",
+  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/tree-pic/node_modules/dependency-tree",
   "author": {
     "name": "Joel Kemp",
     "email": "joel@mrjoelkemp.com",
@@ -65,13 +64,13 @@
     "enhanced-resolve": "~2.2.2",
     "file-exists": "~1.0.0",
     "is-relative-path": "~1.0.0",
-    "module-definition": "^2.2.3",
-    "module-lookup-amd": "^4.0.2",
+    "module-definition": "~2.2.3",
+    "module-lookup-amd": "~4.0.2",
     "object-assign": "~4.0.1",
     "resolve": "~1.1.7",
-    "resolve-dependency-path": "^1.0.2",
-    "sass-lookup": "^1.0.2",
-    "stylus-lookup": "^1.0.1"
+    "resolve-dependency-path": "~1.0.2",
+    "sass-lookup": "~1.0.2",
+    "stylus-lookup": "~1.0.0"
   },
   "description": "Find files based on partial paths",
   "devDependencies": {
@@ -79,16 +78,16 @@
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "~2.2.5",
-    "mock-fs": "~3.11.0",
+    "mock-fs": "~3.7.0",
     "rewire": "~2.3.4",
     "sinon": "~1.15.4"
   },
   "directories": {},
   "dist": {
-    "shasum": "706e320651be278afde35db7e5e34e84c436969b",
-    "tarball": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.4.0.tgz"
+    "shasum": "2c276f55aa97d9c663588299b696718dca2cebdd",
+    "tarball": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.2.11.tgz"
   },
-  "gitHead": "c3c57a80a6bc60a490998c2169181fbc02fcdd21",
+  "gitHead": "ecb9ceefb34d281f44df461831b33c0acab0e992",
   "homepage": "https://github.com/mrjoelkemp/node-filing-cabinet",
   "keywords": [
     "lookup",
@@ -119,5 +118,5 @@
   "scripts": {
     "test": "jscs index.js test/test.js && ./node_modules/.bin/mocha --compilers js:babel/register test/test.js"
   },
-  "version": "1.4.0"
+  "version": "1.2.11"
 }

--- a/node_modules/tree-pic/node_modules/filing-cabinet/readme.md
+++ b/node_modules/tree-pic/node_modules/filing-cabinet/readme.md
@@ -2,7 +2,7 @@
 
 > Look up a filename based on a partial path
 
-`npm install --save filing-cabinet`
+`npm install filing-cabinet`
 
 ### Usage
 
@@ -14,23 +14,17 @@ var result = cabinet({
   partial: 'somePartialPath',
   directory: 'path/to/all/files',
   filename: 'path/to/parent/file',
-  ast: {}, // an optional AST representation of `filename`
-  // Only for JavaScript files
   config: 'path/to/requirejs/config',
   webpackConfig: 'path/to/webpack/config'
 });
 
-console.log(result); // /absolute/path/to/somePartialPath
+console.log(result); // absolute/path/to/somePartialPath
 ```
 
 * `partial`: the dependency path
  * This could be in any of the registered languages
-* `directory`: the path to all files
-* `filename`: the path to the file containing the `partial`
-* `ast`: (optional) the parsed AST for `filename`.
- * Useful optimization for avoiding a parse of filename
-* `config`: (optional) requirejs config for resolving aliased JavaScript modules
-* `webpackConfig`: (optional) webpack config for resolving aliased JavaScript modules
+* `config`: (optional) requirejs config for resolving aliased modules
+* `webpackConfig`: (optional) webpack config for resolving aliased modules
 
 ### Registered languages
 

--- a/node_modules/tree-pic/node_modules/object-assign/index.js
+++ b/node_modules/tree-pic/node_modules/object-assign/index.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-unused-vars */
+'use strict';
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+module.exports = Object.assign || function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (Object.getOwnPropertySymbols) {
+			symbols = Object.getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};

--- a/node_modules/tree-pic/node_modules/object-assign/license
+++ b/node_modules/tree-pic/node_modules/object-assign/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/node_modules/tree-pic/node_modules/object-assign/package.json
+++ b/node_modules/tree-pic/node_modules/object-assign/package.json
@@ -1,0 +1,113 @@
+{
+  "_args": [
+    [
+      {
+        "raw": "object-assign@~4.0.1",
+        "scope": null,
+        "escapedName": "object-assign",
+        "name": "object-assign",
+        "rawSpec": "~4.0.1",
+        "spec": ">=4.0.1 <4.1.0",
+        "type": "range"
+      },
+      "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/tree-pic/node_modules/filing-cabinet"
+    ]
+  ],
+  "_from": "object-assign@>=4.0.1 <4.1.0",
+  "_id": "object-assign@4.0.1",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/tree-pic/object-assign",
+  "_nodeVersion": "3.0.0",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "_npmVersion": "2.13.3",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "object-assign@~4.0.1",
+    "scope": null,
+    "escapedName": "object-assign",
+    "name": "object-assign",
+    "rawSpec": "~4.0.1",
+    "spec": ">=4.0.1 <4.1.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "/tree-pic/filing-cabinet"
+  ],
+  "_resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+  "_shasum": "99504456c3598b5cad4fc59c26e8a9bb107fe0bd",
+  "_shrinkwrap": null,
+  "_spec": "object-assign@~4.0.1",
+  "_where": "/Users/mrjoelkemp/Library/Application Support/Sublime Text 3/Packages/Dependents/node_modules/tree-pic/node_modules/filing-cabinet",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/object-assign/issues"
+  },
+  "dependencies": {},
+  "description": "ES6 Object.assign() ponyfill",
+  "devDependencies": {
+    "lodash": "^3.10.1",
+    "matcha": "^0.6.0",
+    "mocha": "*",
+    "xo": "*"
+  },
+  "directories": {},
+  "dist": {
+    "shasum": "99504456c3598b5cad4fc59c26e8a9bb107fe0bd",
+    "tarball": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "files": [
+    "index.js"
+  ],
+  "gitHead": "b0c40d37cbc43e89ad3326a9bad4c6b3133ba6d3",
+  "homepage": "https://github.com/sindresorhus/object-assign#readme",
+  "keywords": [
+    "object",
+    "assign",
+    "extend",
+    "properties",
+    "es6",
+    "ecmascript",
+    "harmony",
+    "ponyfill",
+    "prollyfill",
+    "polyfill",
+    "shim",
+    "browser"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "name": "object-assign",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/object-assign.git"
+  },
+  "scripts": {
+    "bench": "matcha bench.js",
+    "test": "xo && mocha"
+  },
+  "version": "4.0.1",
+  "xo": {
+    "envs": [
+      "node",
+      "mocha"
+    ]
+  }
+}

--- a/node_modules/tree-pic/node_modules/object-assign/readme.md
+++ b/node_modules/tree-pic/node_modules/object-assign/readme.md
@@ -1,0 +1,51 @@
+# object-assign [![Build Status](https://travis-ci.org/sindresorhus/object-assign.svg?branch=master)](https://travis-ci.org/sindresorhus/object-assign)
+
+> ES6 [`Object.assign()`](http://www.2ality.com/2014/01/object-assign.html) ponyfill
+
+> Ponyfill: A polyfill that doesn't overwrite the native method
+
+
+## Install
+
+```sh
+$ npm install --save object-assign
+```
+
+
+## Usage
+
+```js
+var objectAssign = require('object-assign');
+
+objectAssign({foo: 0}, {bar: 1});
+//=> {foo: 0, bar: 1}
+
+// multiple sources
+objectAssign({foo: 0}, {bar: 1}, {baz: 2});
+//=> {foo: 0, bar: 1, baz: 2}
+
+// overwrites equal keys
+objectAssign({foo: 0}, {foo: 1}, {foo: 2});
+//=> {foo: 2}
+
+// ignores null and undefined sources
+objectAssign({foo: 0}, null, {bar: 1}, undefined);
+//=> {foo: 0, bar: 1}
+```
+
+
+## API
+
+### objectAssign(target, source, [source, ...])
+
+Assigns enumerable own properties of `source` objects to the `target` object and returns the `target` object. Additional `source` objects will overwrite previous ones.
+
+
+## Resources
+
+- [ES6 spec - Object.assign](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign)
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sublime Text plugin to navigate front-end codebases",
   "main": "index.js",
   "dependencies": {
-    "dependents-editor-backend": "~1.14.0"
+    "dependents-editor-backend": "~1.15.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
* filing-cabinet reuses a given ast
* dependents now passes the ast from precinct to filing-cabinet

Results in a 3 to 4 second speedup in some repos